### PR TITLE
Check for go version before running go build cmd

### DIFF
--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import/GoPackage.graph.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import/GoPackage.graph.json
@@ -73,7 +73,7 @@
       "Data": {
         "PkgName": "go_subrepo_import",
         "TypeString": "code.google.com/p/go.tools/go/types.Config",
-        "UnderlyingTypeString": "struct{Strict bool; IgnoreFuncBodies bool; FakeImportC bool; Packages map[string]*code.google.com/p/go.tools/go/types.Package; Error func(err error); Import code.google.com/p/go.tools/go/types.Importer; Sizes code.google.com/p/go.tools/go/types.Sizes}",
+        "UnderlyingTypeString": "struct{IgnoreFuncBodies bool; FakeImportC bool; Packages map[string]*code.google.com/p/go.tools/go/types.Package; Error func(err error); Import code.google.com/p/go.tools/go/types.Importer; Sizes code.google.com/p/go.tools/go/types.Sizes}",
         "Kind": "var",
         "PackageImportPath": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import"
       }


### PR DESCRIPTION
The '-i' flag only exists on go1.3+. Runs the command without '-i' if
the running version of go's version number is less than 1.3.

Related: issue #3.

Signed-off-by: Samer Masterson samer@samertm.com
