### PR TITLE
Fix go1.2

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -34,6 +34,21 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Check that we have the '-i' flag.
+	cmd := exec.Command("go", "help", "build")
+	o, err := cmd.Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	usage := strings.Split(string(o), "\n")[0] // The usage is on the first line.
+	matched, err := regexp.MatchString("-i", usage)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !matched {
+		log.Fatal("'go build' does not have the '-i' flag. Please upgrade to go1.3+.")
+	}
 }
 
 type GraphCmd struct{}
@@ -344,21 +359,6 @@ func doGraph(pkg *build.Package) (*gog.Output, error) {
 		tmpfile, err := ioutil.TempFile("", filepath.Base(importPath))
 		if err != nil {
 			return nil, err
-		}
-
-		// Check that we have the '-i' flag.
-		cmd := exec.Command("go", "help", "build")
-		o, err := cmd.Output()
-		if err != nil {
-			log.Fatal(err)
-		}
-		usage := strings.Split(string(o), "\n")[0] // The usage is on the first line.
-		matched, err := regexp.MatchString("-i", usage)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if !matched {
-			log.Fatal("'go build' does not have the '-i' flag. Please upgrade to go1.3+.")
 		}
 
 		// Install pkg.


### PR DESCRIPTION
go1.2 and below don't have the '-i' flag on 'go build'.
