### PR TITLE
Change SourceImports to ImportFromBinary to follow go/loader updates.

### DIFF
--- a/config.go
+++ b/config.go
@@ -87,7 +87,7 @@ type srcfileConfig struct {
 
 	PkgPatterns []string // pattern passed to `go list` (defaults to {"./..."})
 
-	SourceImports bool
+	ImportFromBinary bool
 }
 
 // unmarshalTypedConfig parses config from the Config field of the source unit.
@@ -160,7 +160,7 @@ func (c *srcfileConfig) apply() error {
 		loaderConfig.Build = &buildContext
 	}
 
-	loaderConfig.SourceImports = config.SourceImports
+	loaderConfig.ImportFromBinary = config.ImportFromBinary
 
 	if config.GOROOTForCmd == "" {
 		config.GOROOTForCmd = config.GOROOT

--- a/graph.go
+++ b/graph.go
@@ -380,7 +380,7 @@ var allowErrorsInGraph = true
 func doGraph(pkg *build.Package) (*gog.Output, error) {
 	importPath := pkg.ImportPath
 
-	if !loaderConfig.SourceImports {
+	if loaderConfig.ImportFromBinary {
 		imports := map[string]struct{}{}
 		for _, imp := range pkg.Imports {
 			imports[imp] = struct{}{}


### PR DESCRIPTION
Reference breaking change in go/loader API
golang/tools@69db398fe0e69396984e3967724820c1f631e971

Fixes sourcegraph/srclib-go#30