### PR TITLE
Use filepath.SplitList to split GOPATH.

### DIFF
--- a/config.go
+++ b/config.go
@@ -151,7 +151,7 @@ func (c *srcfileConfig) apply() error {
 
 	if config.GOPATH != "" {
 		// clean/absolutize all paths
-		dirs := uniq(strings.Split(config.GOPATH, ":"))
+		dirs := uniq(filepath.SplitList(config.GOPATH))
 		for i, dir := range dirs {
 			dir = filepath.Clean(dir)
 			if !filepath.IsAbs(dir) {
@@ -159,9 +159,9 @@ func (c *srcfileConfig) apply() error {
 			}
 			dirs[i] = dir
 		}
-		config.GOPATH = strings.Join(dirs, ":")
+		config.GOPATH = strings.Join(dirs, string(filepath.ListSeparator))
 
-		buildContext.GOPATH += ":" + config.GOPATH
+		buildContext.GOPATH += string(filepath.ListSeparator) + config.GOPATH
 		loaderConfig.Build = &buildContext
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -99,7 +99,7 @@ func (c *GraphCmd) Execute(args []string) error {
 		// For every GOPATH that was in the Srcfile (or autodetected),
 		// move it to a writable dir. (/src is not writable.)
 		if config.GOPATH != "" {
-			dirs := strings.Split(buildContext.GOPATH, ":")
+			dirs := filepath.SplitList(buildContext.GOPATH)
 			for i, dir := range dirs {
 				if dir == mainGOPATHDir || dir == os.Getenv("GOPATH") {
 					continue
@@ -118,7 +118,7 @@ func (c *GraphCmd) Execute(args []string) error {
 				dirs[i] = newGOPATH
 				effectiveConfigGOPATHs = append(effectiveConfigGOPATHs, newSrcDir)
 			}
-			buildContext.GOPATH = strings.Join(dirs, ":")
+			buildContext.GOPATH = strings.Join(dirs, string(filepath.ListSeparator))
 		}
 
 		log.Printf("Changing directory to %q.", dir)

--- a/scan.go
+++ b/scan.go
@@ -61,7 +61,7 @@ func (c *ScanCmd) Execute(args []string) error {
 				log.Printf("Adding %s to GOPATH (auto-detected Go vendored dependencies source dir %s). If you don't want this, make a Srcfile with a GOPATH property set to something other than the empty string.", vdir, filepath.Join(vdir, "src"))
 			}
 		}
-		config.GOPATH = strings.Join(foundGOPATHs, ":")
+		config.GOPATH = strings.Join(foundGOPATHs, string(filepath.ListSeparator))
 	}
 
 	if err := config.apply(); err != nil {
@@ -94,7 +94,7 @@ func (c *ScanCmd) Execute(args []string) error {
 	// Make vendored dep unit names (package import paths) relative to
 	// vendored src dir, not to top-level dir.
 	if config.GOPATH != "" {
-		dirs := strings.Split(config.GOPATH, ":")
+		dirs := filepath.SplitList(config.GOPATH)
 		for _, dir := range dirs {
 			relDir, err := filepath.Rel(cwd, dir)
 			if err != nil {
@@ -133,7 +133,7 @@ func (c *ScanCmd) Execute(args []string) error {
 				u.Config = map[string]interface{}{}
 			}
 
-			dirs := strings.Split(config.GOPATH, ":")
+			dirs := filepath.SplitList(config.GOPATH)
 			for i, dir := range dirs {
 				relDir, err := filepath.Rel(cwd, dir)
 				if err != nil {
@@ -141,7 +141,7 @@ func (c *ScanCmd) Execute(args []string) error {
 				}
 				dirs[i] = relDir
 			}
-			u.Config["GOPATH"] = strings.Join(dirs, ":")
+			u.Config["GOPATH"] = strings.Join(dirs, string(filepath.ListSeparator))
 		}
 	}
 


### PR DESCRIPTION
This is correct and more cross platform.