### PR TITLE
Travis: Use Go 1.4 since it's now stable, make tip allowed failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .bin/
 testdata/actual/
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "testdata/case/gopath-in-repo"]
 	path = testdata/case/gopath-in-repo
 	url = https://github.com/sgtest/gopath-in-repo.git
-[submodule "testdata/case/go13-sample"]
-	path = testdata/case/go13-sample
-	url = https://github.com/sgtest/go13-sample.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: go
 
-go: tip
+go: 1.4.2
 
 before_install:
-  # install go1.4 devel
-  - curl -Lo /tmp/golang.tgz https://go.googlecode.com/archive/e54b1af55910c77e4a215112193472f0276b3c8d.tar.gz
-  - sudo tar -xzf /tmp/golang.tgz -C /usr/local && sudo mv /usr/local/go-* /usr/local/go
-  - sudo bash -c "echo 'devel +e54b1a srclib' > /usr/local/go/VERSION"
-  - cd /usr/local/go/src && sudo ./make.bash
-  - export GOROOT=/usr/local/go
-  - export PATH=/usr/local/go/bin:$PATH
-
   - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph
   - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/sourcegraph.com/sourcegraph/srclib-go
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/sourcegraph.com/sourcegraph/srclib-go

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# srclib-go [![Build Status](https://travis-ci.org/sourcegraph/srclib-go.png?branch=master)](https://travis-ci.org/sourcegraph/srclib-go)
+# srclib-go [![Build Status](https://travis-ci.org/sourcegraph/srclib-go.svg?branch=master)](https://travis-ci.org/sourcegraph/srclib-go)
 
 **srclib-go** is a [srclib](https://srclib.org)
 toolchain that performs Go code analysis: type checking, documentation

--- a/config.go
+++ b/config.go
@@ -166,7 +166,7 @@ func (c *srcfileConfig) apply() error {
 	}
 
 	if config.GOROOTForCmd == "" {
-		config.GOROOTForCmd = config.GOROOT
+		config.GOROOTForCmd = buildContext.GOROOT
 	}
 
 	return nil

--- a/testdata/expected/program/cgo_sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/cgo_sample/GoPackage.depresolve.json
+++ b/testdata/expected/program/cgo_sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/cgo_sample/GoPackage.depresolve.json
@@ -8,7 +8,7 @@
       "ToRepoCloneURL": "https://github.com/golang/go",
       "ToUnit": "fmt",
       "ToUnitType": "GoPackage",
-      "ToVersionString": "go1.4.1",
+      "ToVersionString": "go1.4.2",
       "ToRevSpec": ""
     }
   }

--- a/testdata/expected/program/cgo_sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/cgo_sample/GoPackage.graph.json
+++ b/testdata/expected/program/cgo_sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/cgo_sample/GoPackage.graph.json
@@ -160,5 +160,23 @@
       "Start": 98,
       "End": 105
     }
+  ],
+  "Docs": [
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nThis file does not use cgo and so is not in go/build\u0026#39;s CgoFiles. This is so\nthat the package is detected by go/build.\n\u003c/p\u003e\n\u003cp\u003e\nThere is a bug in srclib-go where packages containing ONLY CgoFiles and no\nGoFiles are not detected.\n\u003c/p\u003e\n",
+      "File": "bar.go",
+      "Start": 20,
+      "End": 253
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "This file does not use cgo and so is not in go/build's CgoFiles. This is so\nthat the package is detected by go/build.\n\nThere is a bug in srclib-go where packages containing ONLY CgoFiles and no\nGoFiles are not detected.\n",
+      "File": "bar.go",
+      "Start": 20,
+      "End": 253
+    }
   ]
 }

--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/exported_methods/GoPackage.graph.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/exported_methods/GoPackage.graph.json
@@ -127,6 +127,20 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nPackage exported_methods tests that srclib-go exports all\ncapitalized methods, even if the type that the method is on is\nunexported.\n\u003c/p\u003e\n",
+      "File": "exported_methods/exported_methods.go",
+      "End": 141
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Package exported_methods tests that srclib-go exports all\ncapitalized methods, even if the type that the method is on is\nunexported.\n",
+      "File": "exported_methods/exported_methods.go",
+      "End": 141
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/exported_methods",
       "Path": ".",

--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import/GoPackage.graph.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import/GoPackage.graph.json
@@ -188,6 +188,20 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nPackage go_subrepo_import tests that srclib-go properly resolves imports of\nGo subrepositories (golang.org/x/*).\n\u003c/p\u003e\n",
+      "File": "go_subrepo_import/go_subrepo_import.go",
+      "End": 118
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Package go_subrepo_import tests that srclib-go properly resolves imports of\nGo subrepositories (golang.org/x/*).\n",
+      "File": "go_subrepo_import/go_subrepo_import.go",
+      "End": 118
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/go_subrepo_import",
       "Path": ".",

--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/multiple_mains/GoPackage.graph.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/multiple_mains/GoPackage.graph.json
@@ -155,5 +155,39 @@
       "Start": 99,
       "End": 105
     }
+  ],
+  "Docs": [
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\ntwo go files in the same dir with defs with identical paths\n\u003c/p\u003e\n",
+      "File": "multiple_mains/main1.go",
+      "Start": 14,
+      "End": 76
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\ntwo go files in the same dir with defs with identical paths\n\u003c/p\u003e\n",
+      "File": "multiple_mains/main2.go",
+      "Start": 14,
+      "End": 76
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "two go files in the same dir with defs with identical paths\n",
+      "File": "multiple_mains/main1.go",
+      "Start": 14,
+      "End": 76
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "two go files in the same dir with defs with identical paths\n",
+      "File": "multiple_mains/main2.go",
+      "Start": 14,
+      "End": 76
+    }
   ]
 }

--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope/GoPackage.depresolve.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope/GoPackage.depresolve.json
@@ -5,7 +5,7 @@
       "ToRepoCloneURL": "https://github.com/golang/go",
       "ToUnit": "fmt",
       "ToUnitType": "GoPackage",
-      "ToVersionString": "go1.4.1",
+      "ToVersionString": "go1.4.2",
       "ToRevSpec": ""
     }
   },
@@ -15,7 +15,7 @@
       "ToRepoCloneURL": "https://github.com/golang/go",
       "ToUnit": "strings",
       "ToUnitType": "GoPackage",
-      "ToVersionString": "go1.4.1",
+      "ToVersionString": "go1.4.2",
       "ToRevSpec": ""
     }
   }

--- a/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope/GoPackage.graph.json
+++ b/testdata/expected/program/go-misc/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope/GoPackage.graph.json
@@ -779,6 +779,104 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nThis package tests Exported and Local.\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "End": 41
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nComments indicate the desired scope. The default is unexported and\nnonlocal. Exported and local defs are marked as such.\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 118,
+      "End": 244
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nx: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 415,
+      "End": 426
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\ny: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 458,
+      "End": 469
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nUnexported type, exported methods\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 775,
+      "End": 811
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "This package tests Exported and Local.\n",
+      "File": "scope/scope.go",
+      "End": 41
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Comments indicate the desired scope. The default is unexported and\nnonlocal. Exported and local defs are marked as such.\n",
+      "File": "scope/scope.go",
+      "Start": 118,
+      "End": 244
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "x: local\n",
+      "File": "scope/scope.go",
+      "Start": 415,
+      "End": 426
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "y: local\n",
+      "File": "scope/scope.go",
+      "Start": 458,
+      "End": 469
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Unexported type, exported methods\n",
+      "File": "scope/scope.go",
+      "Start": 775,
+      "End": 811
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "fmt",
+      "Path": ".",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\n_: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 67,
+      "End": 78
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "fmt",
+      "Path": ".",
+      "Format": "text/plain",
+      "Data": "_: local\n",
+      "File": "scope/scope.go",
+      "Start": 67,
+      "End": 78
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": ".",
@@ -797,112 +895,260 @@
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "A",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nA: exported\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nA: exported\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 277,
+      "End": 291
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "A",
       "Format": "text/plain",
-      "Data": "A: exported\n"
+      "Data": "A: exported\n",
+      "File": "scope/scope.go",
+      "Start": 277,
+      "End": 291
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nT2: exported\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nT2: exported\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 590,
+      "End": 605
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2",
       "Format": "text/plain",
-      "Data": "T2: exported\n"
+      "Data": "T2: exported\n",
+      "File": "scope/scope.go",
+      "Start": 590,
+      "End": 605
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2/F",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nF: exported\na: local\nb: local\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nF: exported\na: local\nb: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 624,
+      "End": 662
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2/F",
       "Format": "text/plain",
-      "Data": "F: exported\na: local\nb: local\n"
+      "Data": "F: exported\na: local\nb: local\n",
+      "File": "scope/scope.go",
+      "Start": 624,
+      "End": 662
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2/g",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\ng: exported type, unexported method\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\ng: exported type, unexported method\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 709,
+      "End": 747
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "T2/g",
       "Format": "text/plain",
-      "Data": "g: exported type, unexported method\n"
+      "Data": "g: exported type, unexported method\n",
+      "File": "scope/scope.go",
+      "Start": 709,
+      "End": 747
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "a",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\na: (unexported)\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\na: (unexported)\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 246,
+      "End": 264
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "a",
       "Format": "text/plain",
-      "Data": "a: (unexported)\n"
+      "Data": "a: (unexported)\n",
+      "File": "scope/scope.go",
+      "Start": 246,
+      "End": 264
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "fn",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nfn\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nfn\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 304,
+      "End": 309
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "fn",
       "Format": "text/plain",
-      "Data": "fn\n"
+      "Data": "fn\n",
+      "File": "scope/scope.go",
+      "Start": 304,
+      "End": 309
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/$scope0/$scope0/T1",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nT1: local\nT1.f: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 525,
+      "End": 554
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/$scope0/$scope0/T1",
+      "Format": "text/plain",
+      "Data": "T1: local\nT1.f: local\n",
+      "File": "scope/scope.go",
+      "Start": 525,
+      "End": 554
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/$scope0/$scope0/Y",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nY: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 490,
+      "End": 501
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/$scope0/$scope0/Y",
+      "Format": "text/plain",
+      "Data": "Y: local\n",
+      "File": "scope/scope.go",
+      "Start": 490,
+      "End": 501
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/T0",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nT0: local\nT0.f: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 356,
+      "End": 384
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/T0",
+      "Format": "text/plain",
+      "Data": "T0: local\nT0.f: local\n",
+      "File": "scope/scope.go",
+      "Start": 356,
+      "End": 384
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/b",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nb: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 323,
+      "End": 334
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
+      "Path": "fn/b",
+      "Format": "text/plain",
+      "Data": "b: local\n",
+      "File": "scope/scope.go",
+      "Start": 323,
+      "End": 334
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "t3/F",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nF: exported\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nF: exported\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 831,
+      "End": 845
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "t3/F",
       "Format": "text/plain",
-      "Data": "F: exported\n"
+      "Data": "F: exported\n",
+      "File": "scope/scope.go",
+      "Start": 831,
+      "End": 845
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "t3/g",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\ng: unexported\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\ng: unexported\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 864,
+      "End": 880
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-misc/scope",
       "Path": "t3/g",
       "Format": "text/plain",
-      "Data": "g: unexported\n"
+      "Data": "g: unexported\n",
+      "File": "scope/scope.go",
+      "Start": 864,
+      "End": 880
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "strings",
+      "Path": ".",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\na: local\n\u003c/p\u003e\n",
+      "File": "scope/scope.go",
+      "Start": 90,
+      "End": 101
+    },
+    {
+      "UnitType": "GoPackage",
+      "Unit": "strings",
+      "Path": ".",
+      "Format": "text/plain",
+      "Data": "a: local\n",
+      "File": "scope/scope.go",
+      "Start": 90,
+      "End": 101
     }
   ]
 }

--- a/testdata/expected/program/go-sample-0/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-sample-0/mypkg/GoPackage.graph.json
+++ b/testdata/expected/program/go-sample-0/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-sample-0/mypkg/GoPackage.graph.json
@@ -185,14 +185,20 @@
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-sample-0/mypkg",
       "Path": "Qux",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nQux is a cool type.\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nQux is a cool type.\n\u003c/p\u003e\n",
+      "File": "mypkg/bar.go",
+      "Start": 15,
+      "End": 37
     },
     {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/go-sample-0/mypkg",
       "Path": "Qux",
       "Format": "text/plain",
-      "Data": "Qux is a cool type.\n"
+      "Data": "Qux is a cool type.\n",
+      "File": "mypkg/bar.go",
+      "Start": 15,
+      "End": 37
     }
   ]
 }

--- a/testdata/expected/program/go13-sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go13-sample/GoPackage.depresolve.json
+++ b/testdata/expected/program/go13-sample/sourcegraph.com/sourcegraph/srclib-go/testdata/case/go13-sample/GoPackage.depresolve.json
@@ -5,7 +5,7 @@
       "ToRepoCloneURL": "https://github.com/golang/go",
       "ToUnit": "fmt",
       "ToUnitType": "GoPackage",
-      "ToVersionString": "go1.4.1",
+      "ToVersionString": "go1.4.2",
       "ToRevSpec": ""
     }
   }

--- a/testdata/expected/program/gopathtest/github.com/alice/mypkg/GoPackage.graph.json
+++ b/testdata/expected/program/gopathtest/github.com/alice/mypkg/GoPackage.graph.json
@@ -62,6 +62,20 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nPackage mypkg is a vendored dependency.\n\u003c/p\u003e\n",
+      "File": "vendor/src/github.com/alice/mypkg/mypkg.go",
+      "End": 42
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Package mypkg is a vendored dependency.\n",
+      "File": "vendor/src/github.com/alice/mypkg/mypkg.go",
+      "End": 42
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "github.com/alice/mypkg",
       "Path": ".",

--- a/testdata/expected/program/gopathtest/github.com/alice/mypkg2/GoPackage.graph.json
+++ b/testdata/expected/program/gopathtest/github.com/alice/mypkg2/GoPackage.graph.json
@@ -84,6 +84,20 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nPackage mypkg2 tests that it can import a vendored dep.\n\u003c/p\u003e\n",
+      "File": "vendor/src/github.com/alice/mypkg2/mypkg2.go",
+      "End": 58
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Package mypkg2 tests that it can import a vendored dep.\n",
+      "File": "vendor/src/github.com/alice/mypkg2/mypkg2.go",
+      "End": 58
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "github.com/alice/mypkg2",
       "Path": ".",

--- a/testdata/expected/program/gopathtest/sourcegraph.com/sourcegraph/srclib-go/testdata/case/gopathtest/GoPackage.graph.json
+++ b/testdata/expected/program/gopathtest/sourcegraph.com/sourcegraph/srclib-go/testdata/case/gopathtest/GoPackage.graph.json
@@ -84,6 +84,20 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nPackage gopathtest tests that it can access vendored deps in vendor/.\n\u003c/p\u003e\n",
+      "File": "gopathtest.go",
+      "End": 72
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Package gopathtest tests that it can access vendored deps in vendor/.\n",
+      "File": "gopathtest.go",
+      "End": 72
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "sourcegraph.com/sourcegraph/srclib-go/testdata/case/gopathtest",
       "Path": ".",

--- a/testdata/expected/program/minimal-go-stdlib/cmd/go/GoPackage.graph.json
+++ b/testdata/expected/program/minimal-go-stdlib/cmd/go/GoPackage.graph.json
@@ -117,5 +117,23 @@
       "Start": 36,
       "End": 40
     }
+  ],
+  "Docs": [
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nTest that we can refer to any pkg defined in the stdlib repo, not just\npkgs from a predefined list. This tests that if the stdlib adds pkgs or\ndefinitions, we\u0026#39;ll analyze them instead of just analyzing the code in\nGOROOT.\n\u003c/p\u003e\n",
+      "File": "src/cmd/go/main.go",
+      "Start": 46,
+      "End": 281
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Test that we can refer to any pkg defined in the stdlib repo, not just\npkgs from a predefined list. This tests that if the stdlib adds pkgs or\ndefinitions, we'll analyze them instead of just analyzing the code in\nGOROOT.\n",
+      "File": "src/cmd/go/main.go",
+      "Start": 46,
+      "End": 281
+    }
   ]
 }

--- a/testdata/expected/program/minimal-go-stdlib/dummy0/GoPackage.graph.json
+++ b/testdata/expected/program/minimal-go-stdlib/dummy0/GoPackage.graph.json
@@ -187,18 +187,56 @@
   ],
   "Docs": [
     {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nFakePrintf should refer to our fake fmt package, not the stdlib package.\n\u003c/p\u003e\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 387,
+      "End": 462
+    },
+    {
+      "Path": "",
+      "Format": "text/html",
+      "Data": "\u003cp\u003e\nRefs to dummy1.MyType test that we can refer to any pkg defined in this repo\nas a stdlib package, not just pkgs from a predefined list. This tests that if\nthe stdlib adds pkgs or definitions, we\u0026#39;ll analyze them instead of just\nanalyzing the code in GOROOT.\n\u003c/p\u003e\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 45,
+      "End": 313
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "FakePrintf should refer to our fake fmt package, not the stdlib package.\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 387,
+      "End": 462
+    },
+    {
+      "Path": "",
+      "Format": "text/plain",
+      "Data": "Refs to dummy1.MyType test that we can refer to any pkg defined in this repo\nas a stdlib package, not just pkgs from a predefined list. This tests that if\nthe stdlib adds pkgs or definitions, we'll analyze them instead of just\nanalyzing the code in GOROOT.\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 45,
+      "End": 313
+    },
+    {
       "UnitType": "GoPackage",
       "Unit": "dummy0",
       "Path": "MyFunc",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nMyFunc documentation should be found.\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nMyFunc documentation should be found.\n\u003c/p\u003e\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 315,
+      "End": 355
     },
     {
       "UnitType": "GoPackage",
       "Unit": "dummy0",
       "Path": "MyFunc",
       "Format": "text/plain",
-      "Data": "MyFunc documentation should be found.\n"
+      "Data": "MyFunc documentation should be found.\n",
+      "File": "src/dummy0/dummy0.go",
+      "Start": 315,
+      "End": 355
     }
   ]
 }

--- a/testdata/expected/program/minimal-go-stdlib/fmt/GoPackage.graph.json
+++ b/testdata/expected/program/minimal-go-stdlib/fmt/GoPackage.graph.json
@@ -103,14 +103,20 @@
       "Unit": "fmt",
       "Path": "FakePrintf",
       "Format": "text/html",
-      "Data": "\u003cp\u003e\nFakePrintf is not the real printf. We\u0026#39;re testing that our analyzer looks at\nthe repository being analyzed, and not the Go stdlib, if GoBaseImportPaths is\nset.\n\u003c/p\u003e\n"
+      "Data": "\u003cp\u003e\nFakePrintf is not the real printf. We\u0026#39;re testing that our analyzer looks at\nthe repository being analyzed, and not the Go stdlib, if GoBaseImportPaths is\nset.\n\u003c/p\u003e\n",
+      "File": "src/fmt/fake_fmt.go",
+      "Start": 13,
+      "End": 180
     },
     {
       "UnitType": "GoPackage",
       "Unit": "fmt",
       "Path": "FakePrintf",
       "Format": "text/plain",
-      "Data": "FakePrintf is not the real printf. We're testing that our analyzer looks at\nthe repository being analyzed, and not the Go stdlib, if GoBaseImportPaths is\nset.\n"
+      "Data": "FakePrintf is not the real printf. We're testing that our analyzer looks at\nthe repository being analyzed, and not the Go stdlib, if GoBaseImportPaths is\nset.\n",
+      "File": "src/fmt/fake_fmt.go",
+      "Start": 13,
+      "End": 180
     }
   ]
 }


### PR DESCRIPTION
Fix Travis build.

The last time it was modified, 1.3 was stable and 1.4 was tip, which was needed for some changes. Now 1.4 is stable, so we can use that for main testing instead.

- Many test cases expected output needed to be updated.

- A bug with `GOROOTForCmd` incorrectly ignoring env vars needed to be fixed, see commit message of 686e98eec59e0bb0248fab82d745b871caaa62f0.

- Go 1.3 test was removed.

Resolves #37.