### PR TITLE
Use manual GOPATH instead of godep for installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
 CURRENT_MAKEFILE_LIST := $(MAKEFILE_LIST)
-makefileDir := $(dir $(firstword $(CURRENT_MAKEFILE_LIST)))
+makefileDir := $(abspath $(dir $(firstword $(CURRENT_MAKEFILE_LIST))))
 
 .PHONY: install test gotest srctest
 
 install:
 	@mkdir -p .bin
-	go get github.com/tools/godep
-	godep go build -o .bin/srclib-go
+	GOPATH="$(makefileDir)/Godeps/_workspace:$(GOPATH)" go build -o .bin/srclib-go
 
 test: gotest srctest
-	godep go test ./...
+	GOPATH="$(makefileDir)/Godeps/_workspace:$(GOPATH)" go test ./...
 	src test -m program
 
 gotest:
-	godep go test ./...
+	GOPATH="$(makefileDir)/Godeps/_workspace:$(GOPATH)" go test ./...
 
 srctest:
 	git submodule update --init


### PR DESCRIPTION
This change removes the need to godep tool during installation, replacing its functionality with manually setting GOPATH to prepend the Godeps/_workspace subdirectory.

#### First Attempt

Initially, I tried `GOPATH="$(PWD)/Godeps/_workspace:$(GOPATH)"` but that fails when running the Makefile from another directory (via `-C` flag to `make` command). When Sourcegraph binary installs srclib-go, the current working directory is where the user starts the Sourcegraph binary, not where this Makefile ends up being cloned to.

#### Second Change

Next up I tried to use `$(makefileDir)` since it was already in this Makefile, but unused. It seemed like something that would get the path to the actual Makefile, rather than current working directory, which is what is desired.

However, that failed because the value of `$(makefileDir)` ended up being "./":

```
GOPATH=".//Godeps/_workspace:/home/ubuntu/GoPath" go build -o .bin/srclib-go
go: GOPATH entry is relative; must be absolute path: ".//Godeps/_workspace".
Run 'go help gopath' for usage.
Makefile:7: recipe for target 'install' failed
```

#### Third Change

That's why I needed to use `$(abspath ...)` to convert that to an absolute path, which seemed to work.

## Conclusion

In the end, I don't think this change is an improvement in any way and therefore I don't think it should be merged as is. I'm just posting it here for review and perhaps suggestions that will make this better.

But IMO I am much more confident in the following two lines working for the next 2 years without issue anywhere there's a valid Go installation:

```
go get github.com/tools/godep
godep go build -o .bin/srclib-go
```

The above is simple, reliable and readable. Compared to relying on magic of `make`, which has many variations and different versions across OS X, Linux and Windows:

```
CURRENT_MAKEFILE_LIST := $(MAKEFILE_LIST)
makefileDir := $(abspath $(dir $(firstword $(CURRENT_MAKEFILE_LIST))))
GOPATH="$(makefileDir)/Godeps/_workspace:$(GOPATH)" go build -o .bin/srclib-go
```

Note that in both situations the user does not need to do anything different except run the Makefile. Comments are welcome, but as I said, I don't think this should be merged as is.