### PR TITLE
Rely on a locally installed copy of godep binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,15 @@ makefileDir := $(dir $(firstword $(CURRENT_MAKEFILE_LIST)))
 .PHONY: install test gotest srctest
 
 install:
-	@mkdir -p .bin
-	go get github.com/tools/godep
-	godep go build -o .bin/srclib-go
+	GOBIN=.bin go get github.com/tools/godep
+	.bin/godep go build -o .bin/srclib-go
 
 test: gotest srctest
-	godep go test ./...
+	.bin/godep go test ./...
 	src test -m program
 
 gotest:
-	godep go test ./...
+	.bin/godep go test ./...
 
 srctest:
 	git submodule update --init


### PR DESCRIPTION
Install godep into a local .bin folder. That way, it will always be accessible even if the user does not have $GOPATH/bin added to their $PATH.

This is an implementation of the alternative idea described in https://github.com/sourcegraph/srclib-go/pull/46#issuecomment-130409912. Review and thoughts are welcome.

Closes #46.