### PR TITLE
scan: ignore dirs with multiple packages

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -291,7 +291,10 @@ func scanForPackages(dir string) ([]*build.Package, error) {
 		if info.IsDir() && ((name[0] != '.' && name[0] != '_' && name != "testdata") || (strings.HasSuffix(filepath.ToSlash(fullPath), "/Godeps/_workspace") && !config.SkipGodeps)) {
 			subPkgs, err := scanForPackages(fullPath)
 			if err != nil {
-				return nil, err
+				// if dir contains multiple packages, ignore it and continue.
+				if _, ok := err.(*build.MultiplePackageError); !ok {
+					return nil, err
+				}
 			}
 			pkgs = append(pkgs, subPkgs...)
 		}

--- a/scan.go
+++ b/scan.go
@@ -275,9 +275,9 @@ func scanForPackages(dir string) ([]*build.Package, error) {
 
 	pkg, err := buildContext.ImportDir(dir, 0)
 	if err != nil {
-		switch e := err.(type) {
+		switch err.(type) {
 		case *build.NoGoError, *build.MultiplePackageError:
-			break
+			// These errors are not fatal, continue.
 		default:
 			return nil, err
 		}


### PR DESCRIPTION
This will fix build errors in repositories where some directories might contain source files from different packages, by ignoring those directories. Usually such directories are example code files, eg https://github.com/golang/go/tree/master/doc/progs, so it is okay to ignore them in the build.