### PR TITLE
added ImportPathRoot config

### DIFF
--- a/config.go
+++ b/config.go
@@ -109,6 +109,10 @@ type srcfileConfig struct {
 	// to the files in their respective repositories instead of the local copies
 	// inside of Godeps/_workspace.
 	SkipGodeps bool
+
+	// ImportPathRoot is a prefix which is used when converting from repository
+	// URI to Go import path.
+	ImportPathRoot string
 }
 
 // unmarshalTypedConfig parses config from the Config field of the source unit.

--- a/scan.go
+++ b/scan.go
@@ -72,7 +72,7 @@ func (c *ScanCmd) Execute(args []string) error {
 	}
 	scanDir := cwd
 	if !isInGopath(scanDir) {
-		scanDir = filepath.Join(cwd, srclibGopath, "src", filepath.FromSlash(c.Repo))
+		scanDir = filepath.Join(cwd, srclibGopath, "src", filepath.FromSlash(config.ImportPathRoot), filepath.FromSlash(c.Repo))
 		buildContext.GOPATH = filepath.Join(cwd, srclibGopath) + string(os.PathListSeparator) + buildContext.GOPATH
 
 		os.RemoveAll(srclibGopath) // ignore error


### PR DESCRIPTION
Up until now the assumption `sourcegraph repo path == git remote URI == go import path` was usually true. If we want to break this assumption, then we'll need some mapping between repo path and go import path. This mapping then needs to be used for creating the synthesized gopath (implemented in this PR) and for mapping other repositories' import paths back to the repo path (not yet implemented). 