### PR TITLE
Fetch deps if SRCLIB_FETCH_DEPS env var is set

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/build"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -71,14 +72,18 @@ func (c *GraphCmd) Execute(args []string) error {
 		return err
 	}
 
-	if os.Getenv("IN_DOCKER_CONTAINER") != "" {
+	if os.Getenv("IN_DOCKER_CONTAINER") != "" || os.Getenv("SRCLIB_FETCH_DEPS") != "" {
 		buildPkg, err := UnitDataAsBuildPackage(unit)
 		if err != nil {
 			return err
 		}
 
 		// Make a new primary GOPATH.
-		mainGOPATHDir := filepath.Join(os.TempDir(), "gopath")
+		mainGOPATHDir, err := ioutil.TempDir("", "gopath")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(mainGOPATHDir)
 		if buildContext.GOPATH == "" {
 			buildContext.GOPATH = mainGOPATHDir
 		} else {


### PR DESCRIPTION
Currently the grapher only fetches deps (with go get) if IN_DOCKER_CONTAINER is true:

https://github.com/sourcegraph/srclib-go/blob/fd67bff078ee774c13278bd6e709ee4ef7c30136/graph.go#L150

This makes sense if you are running srclib in your development GOPATH; you don't want it checking out different revisions of your GOPATH code. But if you are running srclib-go on a dedicated server without Docker, you do want it to create a temporary GOPATH and fetch deps, just like it would if Docker were enabled.

The current behavior results in unresolved refs for any deps that aren't already in the GOPATH, which means a lot of unresolved refs if running on a dedicated, non-Docker server.