### PR TITLE
golang_def: return proper keyword for const and interface

### DIFF
--- a/golang_def/def.go
+++ b/golang_def/def.go
@@ -53,6 +53,10 @@ func (f defFormatter) DefKeyword() string {
 		return "type"
 	case definfo.Package:
 		return "package"
+	case definfo.Interface:
+		return "interface"
+	case definfo.Const:
+		return "const"
 	}
 	return ""
 }


### PR DESCRIPTION
Fixes #62