### PR TITLE
fix depresolve for Go 1.6 vendor dependencies

### DIFF
--- a/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sgtest/go15vendor/GoPackage.graph.json
+++ b/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sgtest/go15vendor/GoPackage.graph.json
@@ -58,7 +58,15 @@
     },
     {
       "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "DefUnit": "github.com/sgtest/go15vendor",
+      "DefPath": ".",
+      "File": "main.go",
+      "Start": 8,
+      "End": 12
+    },
+    {
+      "DefUnitType": "GoPackage",
+      "DefUnit": "github.com/sourcegraph/john-test/hi",
       "DefPath": ".",
       "File": "main.go",
       "Start": 136,
@@ -66,19 +74,11 @@
     },
     {
       "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "DefUnit": "github.com/sourcegraph/john-test/hi",
       "DefPath": ".",
       "File": "main.go",
       "Start": 68,
       "End": 105
-    },
-    {
-      "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor",
-      "DefPath": ".",
-      "File": "main.go",
-      "Start": 8,
-      "End": 12
     },
     {
       "DefRepo": "github.com/golang/go",
@@ -117,7 +117,7 @@
     },
     {
       "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "DefUnit": "github.com/sourcegraph/john-test/hi",
       "DefPath": "GetHi",
       "File": "main.go",
       "Start": 139,

--- a/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sourcegraph/john-test/hi/GoPackage.graph.json
+++ b/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sourcegraph/john-test/hi/GoPackage.graph.json
@@ -2,7 +2,7 @@
   "Defs": [
     {
       "UnitType": "GoPackage",
-      "Unit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "Unit": "github.com/sourcegraph/john-test/hi",
       "Path": ".",
       "Name": "hi",
       "Kind": "package",
@@ -21,7 +21,7 @@
     },
     {
       "UnitType": "GoPackage",
-      "Unit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "Unit": "github.com/sourcegraph/john-test/hi",
       "Path": "GetHi",
       "Name": "GetHi",
       "Kind": "func",
@@ -44,7 +44,7 @@
   "Refs": [
     {
       "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "DefUnit": "github.com/sourcegraph/john-test/hi",
       "DefPath": ".",
       "File": "vendor/github.com/sourcegraph/john-test/hi/hi.go",
       "Start": 8,
@@ -52,7 +52,7 @@
     },
     {
       "DefUnitType": "GoPackage",
-      "DefUnit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "DefUnit": "github.com/sourcegraph/john-test/hi",
       "DefPath": "GetHi",
       "Def": true,
       "File": "vendor/github.com/sourcegraph/john-test/hi/hi.go",
@@ -72,7 +72,7 @@
   "Docs": [
     {
       "UnitType": "GoPackage",
-      "Unit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "Unit": "github.com/sourcegraph/john-test/hi",
       "Path": "GetHi",
       "Format": "text/html",
       "Data": "\u003cp\u003e\nGetHi returns a string saying hi\n\u003c/p\u003e\n",
@@ -82,7 +82,7 @@
     },
     {
       "UnitType": "GoPackage",
-      "Unit": "github.com/sgtest/go15vendor/vendor/github.com/sourcegraph/john-test/hi",
+      "Unit": "github.com/sourcegraph/john-test/hi",
       "Path": "GetHi",
       "Format": "text/plain",
       "Data": "GetHi returns a string saying hi\n",


### PR DESCRIPTION
This will fix references to Go-1.6-vendored code.