### PR TITLE
graph: accept a list of source units as input to graph

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -64,11 +64,11 @@ func (c *GraphCmd) Execute(args []string) error {
 	var units unit.SourceUnits
 	if err := json.NewDecoder(bytes.NewReader(inputBytes)).Decode(&units); err != nil {
 		// Legacy API: try parsing input as a single source unit
-		var unit *unit.SourceUnit
-		if err := json.NewDecoder(bytes.NewReader(inputBytes)).Decode(&unit); err != nil {
+		var u *unit.SourceUnit
+		if err := json.NewDecoder(bytes.NewReader(inputBytes)).Decode(&u); err != nil {
 			return err
 		}
-		units = append(units, unit)
+		units = unit.SourceUnits{u}
 	}
 	if err := os.Stdin.Close(); err != nil {
 		return err

--- a/graph.go
+++ b/graph.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/build"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -55,11 +57,15 @@ var graphCmd GraphCmd
 var allowErrorsInGoGet = true
 
 func (c *GraphCmd) Execute(args []string) error {
+	inputBytes, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
 	var units unit.SourceUnits
-	if err := json.NewDecoder(os.Stdin).Decode(&units); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(inputBytes)).Decode(&units); err != nil {
 		// Legacy API: try parsing input as a single source unit
 		var unit *unit.SourceUnit
-		if err := json.NewDecoder(os.Stdin).Decode(&unit); err != nil {
+		if err := json.NewDecoder(bytes.NewReader(inputBytes)).Decode(&unit); err != nil {
 			return err
 		}
 		units = append(units, unit)

--- a/graph.go
+++ b/graph.go
@@ -74,6 +74,10 @@ func (c *GraphCmd) Execute(args []string) error {
 		return err
 	}
 
+	if len(units) == 0 {
+		log.Fatal("Input contains no source unit data.")
+	}
+
 	// HACK: fix this. Is this required? We only seem to be setting
 	// GOROOT and GOPATH
 	if err := unmarshalTypedConfig(units[0].Config); err != nil {


### PR DESCRIPTION
This change will allow srclib-go to graph multiple packages together.
The benefit of this is that we can graph all source units of a repo
together, taking advantage of the caching in go/loader and gog packages,
to avoid doing duplicate work of loading and parsing the same dependencies
multiple times.

TODO: fix the global config setting in graph.go