### PR TITLE
gog: do not fail if the doc file cannot be opened

### DIFF
--- a/gog/doc.go
+++ b/gog/doc.go
@@ -43,7 +43,8 @@ func parseFiles(fset *token.FileSet, filenames []string) (map[string]*ast.File, 
 			f, err = os.Open(path)
 		}
 		if err != nil {
-			return nil, err
+			log.Printf("Warning: parseFiles on %q: %s.", path, err)
+			continue
 		}
 		defer f.Close()
 


### PR DESCRIPTION
Fixes an undesired fatal error when a Go file contains a comment such as the following referring to a file that does not exist.

```
//line doesntexist.go:4
package foo
/* ... */
```