### PR TITLE
graph: gracefully handle error in graphing single source unit

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -131,7 +131,8 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 	for _, u := range units {
 		pkg, err := UnitDataAsBuildPackage(u)
 		if err != nil {
-			return nil, err
+			log.Printf("Ignoring unit %q due to error in converting to build pkg: %s.", u.Name, err)
+			continue
 		}
 		pkgs = append(pkgs, pkg)
 	}
@@ -146,7 +147,8 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 	for _, gs := range o.Defs {
 		d, err := convertGoDef(gs)
 		if err != nil {
-			return nil, err
+			log.Printf("Ignoring def %v due to error in converting to GoDef: %s.", gs, err)
+			continue
 		}
 		if d != nil {
 			o2.Defs = append(o2.Defs, d)
@@ -155,7 +157,8 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 	for _, gr := range o.Refs {
 		r, err := convertGoRef(gr)
 		if err != nil {
-			return nil, err
+			log.Printf("Ignoring ref %v due to error in converting to GoRef: %s.", gr, err)
+			continue
 		}
 		if r != nil {
 			o2.Refs = append(o2.Refs, r)
@@ -164,7 +167,8 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 	for _, gd := range o.Docs {
 		d, err := convertGoDoc(gd)
 		if err != nil {
-			return nil, err
+			log.Printf("Ignoring doc %v due to error in converting to GoDoc: %s.", gd, err)
+			continue
 		}
 		if d != nil {
 			o2.Docs = append(o2.Docs, d)
@@ -368,7 +372,7 @@ func doGraph(pkgs []*build.Package) (*gog.Output, error) {
 
 	for _, pkg := range pkgInfos {
 		if err := g.Graph(pkg); err != nil {
-			return nil, err
+			log.Printf("Ignoring pkg %q due to error in gog.Graph: %s.", pkg.Pkg.Name(), err)
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -57,6 +57,7 @@
 			"revisionTime": "2016-02-20T17:33:56-05:00"
 		},
 		{
+			"checksumSHA1": "Ymuplsf82NNHBZUgUT/nM/U4BpM=",
 			"path": "golang.org/x/tools/go/gcimporter15",
 			"revision": "b75b3f5cd5d50fbb1fb88ce784d2e7cca17bba8a",
 			"revisionTime": "2016-04-03T16:33:36-07:00"
@@ -98,7 +99,7 @@
 			"revisionTime": "2016-03-24T15:23:09+01:00"
 		},
 		{
-			"checksumSHA1": "DQegZodz5GxmUbCOPySjzei4Zbw=",
+			"checksumSHA1": "seWWPqWX4VyY7hsix0woW6OYLAY=",
 			"path": "sourcegraph.com/sourcegraph/srclib",
 			"revision": "2c38b1042a946ec4531ca463bf6e65d7a356190b",
 			"revisionTime": "2016-01-07T01:13:23-08:00"
@@ -128,7 +129,7 @@
 			"revisionTime": "2016-01-07T01:13:23-08:00"
 		},
 		{
-			"checksumSHA1": "y1FdQWZzVB6Ssln91LjRD4AiMIM=",
+			"checksumSHA1": "hYUGZVDD9sRAxEGqEvfeQUpzK6o=",
 			"path": "sourcegraph.com/sourcegraph/srclib/graph",
 			"revision": "2c38b1042a946ec4531ca463bf6e65d7a356190b",
 			"revisionTime": "2016-01-07T01:13:23-08:00"
@@ -146,7 +147,7 @@
 			"revisionTime": "2016-03-29T22:33:49-07:00"
 		},
 		{
-			"checksumSHA1": "Eff/+/OaGHAVErr2rEnQO1Szi5U=",
+			"checksumSHA1": "DO2ClRpKhE9dkk3dJ2L0tdkDnRc=",
 			"path": "sourcegraph.com/sourcegraph/srclib/unit",
 			"revision": "2c38b1042a946ec4531ca463bf6e65d7a356190b",
 			"revisionTime": "2016-01-07T01:13:23-08:00"


### PR DESCRIPTION
This modifies the graphing code to log and ignore errors that occur
while graphing a single source unit, so that the graph data from
other source units is returned successfully.