### PR TITLE
depresolve: use newer tools/go/vcs package to resolve import paths

### DIFF
--- a/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/go_subrepo_import/GoPackage.depresolve.json
+++ b/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/go_subrepo_import/GoPackage.depresolve.json
@@ -13,7 +13,7 @@
     "Raw": "golang.org/x/net/ipv6",
     "Target": {
       "ToRepoCloneURL": "https://github.com/golang/net",
-      "ToUnit": "golang.org/x/net/ipv6",
+      "ToUnit": "github.com/golang/net/ipv6",
       "ToUnitType": "GoPackage",
       "ToVersionString": "",
       "ToRevSpec": ""

--- a/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/go_subrepo_import/GoPackage.graph.json
+++ b/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/go_subrepo_import/GoPackage.graph.json
@@ -112,7 +112,7 @@
     {
       "DefRepo": "github.com/golang/net",
       "DefUnitType": "GoPackage",
-      "DefUnit": "golang.org/x/net/ipv6",
+      "DefUnit": "github.com/golang/net/ipv6",
       "DefPath": ".",
       "Unit": "github.com/sgtest/go-misc/go_subrepo_import",
       "File": "go_subrepo_import/go_subrepo_import.go",
@@ -122,7 +122,7 @@
     {
       "DefRepo": "github.com/golang/net",
       "DefUnitType": "GoPackage",
-      "DefUnit": "golang.org/x/net/ipv6",
+      "DefUnit": "github.com/golang/net/ipv6",
       "DefPath": ".",
       "Unit": "github.com/sgtest/go-misc/go_subrepo_import",
       "File": "go_subrepo_import/go_subrepo_import.go",
@@ -142,7 +142,7 @@
     {
       "DefRepo": "github.com/golang/net",
       "DefUnitType": "GoPackage",
-      "DefUnit": "golang.org/x/net/ipv6",
+      "DefUnit": "github.com/golang/net/ipv6",
       "DefPath": "Conn",
       "Unit": "github.com/sgtest/go-misc/go_subrepo_import",
       "File": "go_subrepo_import/go_subrepo_import.go",


### PR DESCRIPTION
This changes the ResolveDep method to use the vcs.RepoRootForImportPath
method to resolve external package import paths, which is more stable
than the earlier gosrc.Get call. Additionally, this new call does not
incur a GitHub API request.

This change also makes it so that the Unit name of the resolved dep is
modified to have the base set to the root of the clone URL of the repo.
This ensures that the ref is resolved to the proper def, since the
def will not have a custom import path in its unit name when graphed by
srclib-go (since srclib-go does not have information about a repo's
custom import paths).

For eg, the `golang.org/x/net/context.Context` def will have the def key:
   Repo: github.com/golang/net
   Unit: github.com/golang/net/context
   UnitType: GoPackage
   Path: Context

Note how the Unit name is 'github.com/golang/net/context' and not
'golang.org/x/net/context'. This change ensures that refs to such defs
are always resolved correctly.