### PR TITLE
remove special casing of clone url resolution for sourcegraph repos

### DIFF
--- a/depresolve/depresolve.go
+++ b/depresolve/depresolve.go
@@ -26,7 +26,7 @@ func ResolveImportPath(importPath string) (*dep.ResolvedTarget, error) {
 		target.ToRevSpec = "" // TODO(sqs): fill in when graphing stdlib repo
 
 	// Special-case github.com/... import paths for performance.
-	case strings.HasPrefix(importPath, "github.com/") || strings.HasPrefix(importPath, "sourcegraph.com/"):
+	case strings.HasPrefix(importPath, "github.com/"):
 		cloneURL, err := standardRepoHostImportPathToCloneURL(importPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Some repos have their clone url set to GitHub, so the resolution is currently wrong.
Resolves https://app.asana.com/0/91952577398025/119909364822594