### PR TITLE
Depresolve: fixed bugs and special cases. 

### DIFF
--- a/depresolve/depresolve_test.go
+++ b/depresolve/depresolve_test.go
@@ -1,0 +1,48 @@
+// +build nettest
+
+package depresolve_test
+
+import (
+	"reflect"
+	"testing"
+
+	"sourcegraph.com/sourcegraph/srclib-go/depresolve"
+	"sourcegraph.com/sourcegraph/srclib/dep"
+)
+
+// TestResolveImportPath tests the behavior of ResolveImportPath
+// when called on some common Go package import paths.
+func TestResolveImportPath(t *testing.T) {
+	tests := []struct {
+		ImportPath string
+		Result     *dep.ResolvedTarget
+	}{
+		{"k8s.io/kubernetes/pkg/api", &dep.ResolvedTarget{"https://github.com/kubernetes/kubernetes", "github.com/kubernetes/kubernetes/pkg/api", "GoPackage", "", ""}},
+		{"gopkg.in/inconshreveable/log15.v2", &dep.ResolvedTarget{"https://gopkg.in/inconshreveable/log15.v2", "gopkg.in/inconshreveable/log15.v2", "GoPackage", "", ""}},
+		{"azul3d.org/semver.v2", &dep.ResolvedTarget{"https://azul3d.org/semver.v2", "azul3d.org/semver.v2", "GoPackage", "", ""}},
+		{"sourcegraph.com/sourcegraph/srclib/graph", &dep.ResolvedTarget{"https://sourcegraph.com/sourcegraph/srclib", "sourcegraph.com/sourcegraph/srclib/graph", "GoPackage", "", ""}},
+		{"sourcegraph.com/sourcegraph/sourcegraph/app", &dep.ResolvedTarget{"https://sourcegraph.com/sourcegraph/sourcegraph", "sourcegraph.com/sourcegraph/sourcegraph/app", "GoPackage", "", ""}},
+		{"google.golang.org/grpc", &dep.ResolvedTarget{"https://github.com/grpc/grpc-go", "github.com/grpc/grpc-go", "GoPackage", "", ""}},
+		{"google.golang.org/grpc/codes", &dep.ResolvedTarget{"https://github.com/grpc/grpc-go", "github.com/grpc/grpc-go/codes", "GoPackage", "", ""}},
+		{"google.golang.org/appengine", &dep.ResolvedTarget{"https://github.com/golang/appengine", "github.com/golang/appengine", "GoPackage", "", ""}},
+		{"google.golang.org/appengine/channel", &dep.ResolvedTarget{"https://github.com/golang/appengine", "github.com/golang/appengine/channel", "GoPackage", "", ""}},
+		{"google.golang.org/cloud", &dep.ResolvedTarget{"https://github.com/GoogleCloudPlatform/gcloud-golang", "github.com/GoogleCloudPlatform/gcloud-golang", "GoPackage", "", ""}},
+		{"google.golang.org/cloud/bigtable", &dep.ResolvedTarget{"https://github.com/GoogleCloudPlatform/gcloud-golang", "github.com/GoogleCloudPlatform/gcloud-golang/bigtable", "GoPackage", "", ""}},
+		{"google.golang.org/api", &dep.ResolvedTarget{"https://github.com/google/google-api-go-client", "github.com/google/google-api-go-client", "GoPackage", "", ""}},
+		{"google.golang.org/api/analytics/v3", &dep.ResolvedTarget{"https://github.com/google/google-api-go-client", "github.com/google/google-api-go-client/analytics/v3", "GoPackage", "", ""}},
+		{"golang.org/x/net/context", &dep.ResolvedTarget{"https://github.com/golang/net", "github.com/golang/net/context", "GoPackage", "", ""}},
+		{"golang.org/x/crypto/ssh", &dep.ResolvedTarget{"https://github.com/golang/crypto", "github.com/golang/crypto/ssh", "GoPackage", "", ""}},
+		{"gopkg.in/redis.v3/internal/hashtag", &dep.ResolvedTarget{"https://gopkg.in/redis.v3", "gopkg.in/redis.v3/internal/hashtag", "GoPackage", "", ""}},
+		{"github.com/gorilla/mux", &dep.ResolvedTarget{"https://github.com/gorilla/mux", "github.com/gorilla/mux", "GoPackage", "", ""}},
+		{"github.com/aws/aws-sdk-go/aws/request", &dep.ResolvedTarget{"https://github.com/aws/aws-sdk-go", "github.com/aws/aws-sdk-go/aws/request", "GoPackage", "", ""}},
+	}
+	for _, test := range tests {
+		got, err := depresolve.ResolveImportPath(test.ImportPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.Result) {
+			t.Errorf("failed:\ngot : %#v\nwant: %#v", got, test.Result)
+		}
+	}
+}

--- a/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sgtest/go15vendor/GoPackage.depresolve.json
+++ b/testdata/expected/src/github.com/sgtest/go15vendor/github.com/sgtest/go15vendor/GoPackage.depresolve.json
@@ -12,7 +12,7 @@
   {
     "Raw": "github.com/sgtest/go-vendored-lib/hi",
     "Target": {
-      "ToRepoCloneURL": "https://github.com/sgtest/go-vendored-lib.git",
+      "ToRepoCloneURL": "https://github.com/sgtest/go-vendored-lib",
       "ToUnit": "github.com/sgtest/go-vendored-lib/hi",
       "ToUnitType": "GoPackage",
       "ToVersionString": "",


### PR DESCRIPTION
Fixed so that not all "google.golang.org" repos are treated the same, instead three (of the four) have special cases. These are for efficiency reasons, and because sourcegraph.com hosts their github.com mirrors.

Fixed bugs. Instead of doing a `strings.Replace` to get the `ToRepoCloneURL`, the cloneURLs are just put in for special cases, for example "google.golang.org/grpc".

Tests are added to ensure correctness and prevent regressions. The tests are marked with a build tag so that they are not called every time this repo is built, as depresolve makes network calls that can be slow.

These changes make depresolve more accurate, which in turn helps any project that wants a more accurate CloneURL resolution.