### PR TITLE
crude workaround for path collisions

### DIFF
--- a/gog/graph.go
+++ b/gog/graph.go
@@ -39,6 +39,7 @@ type grapher struct {
 	funcNames  map[*types.Scope]string
 
 	paths      map[types.Object][]string
+	usedPaths  map[string]struct{}
 	scopePaths map[*types.Scope][]string
 	pkgscope   map[types.Object]bool
 	selRecvs   map[types.Object]types.Type
@@ -69,6 +70,7 @@ func Graph(fset *token.FileSet, files []*ast.File, typesPkg *types.Package, type
 		funcNames:  make(map[*types.Scope]string),
 
 		paths:      make(map[types.Object][]string),
+		usedPaths:  make(map[string]struct{}),
 		scopePaths: make(map[*types.Scope][]string),
 		pkgscope:   make(map[types.Object]bool),
 		selRecvs:   make(map[types.Object]types.Type),

--- a/gog/scope.go
+++ b/gog/scope.go
@@ -169,7 +169,7 @@ func (g *grapher) assignPaths(s *types.Scope, prefix []string, pkgscope bool) {
 			continue
 		}
 		path := append(append([]string{}, prefix...), name)
-		g.paths[e] = path
+		g.addPath(e, path)
 		g.pkgscope[e] = pkgscope
 
 		if tn, ok := e.(*types.TypeName); ok {
@@ -222,7 +222,7 @@ func (g *grapher) assignMethodPaths(named *types.Named, prefix []string, pkgscop
 	for i := 0; i < named.NumMethods(); i++ {
 		m := named.Method(i)
 		path := append(append([]string{}, prefix...), m.Name())
-		g.paths[m] = path
+		g.addPath(m, path)
 
 		g.pkgscope[m] = pkgscope
 
@@ -235,7 +235,7 @@ func (g *grapher) assignMethodPaths(named *types.Named, prefix []string, pkgscop
 		for i := 0; i < iface.NumExplicitMethods(); i++ {
 			m := iface.Method(i)
 			path := append(append([]string{}, prefix...), m.Name())
-			g.paths[m] = path
+			g.addPath(m, path)
 
 			g.pkgscope[m] = pkgscope
 
@@ -250,7 +250,7 @@ func (g *grapher) assignStructFieldPaths(styp *types.Struct, prefix []string, pk
 	for i := 0; i < styp.NumFields(); i++ {
 		f := styp.Field(i)
 		path := append(append([]string{}, prefix...), f.Name())
-		g.paths[f] = path
+		g.addPath(f, path)
 
 		g.pkgscope[f] = pkgscope
 
@@ -272,6 +272,18 @@ func (g *grapher) pathEnclosingInterval(start, end token.Pos) ([]ast.Node, bool)
 		}
 	}
 	return nil, false
+}
+
+func (g *grapher) addPath(obj types.Object, path []string) {
+	for {
+		_, ok := g.usedPaths[strings.Join(path, "/")]
+		if !ok {
+			break
+		}
+		path = append(path, "1") // crude workaround for path collisions, proper fix needs major rewrite of this code based on AST traversal
+	}
+	g.paths[obj] = path
+	g.usedPaths[strings.Join(path, "/")] = struct{}{}
 }
 
 func tokenFileContainsPos(f *token.File, pos token.Pos) bool {

--- a/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/multiple_mains/GoPackage.graph.json
+++ b/testdata/expected/src/github.com/sgtest/go-misc/github.com/sgtest/go-misc/multiple_mains/GoPackage.graph.json
@@ -60,7 +60,7 @@
     {
       "UnitType": "GoPackage",
       "Unit": "github.com/sgtest/go-misc/multiple_mains",
-      "Path": "main2.go/main/x",
+      "Path": "main2.go/main/x/1",
       "Name": "x",
       "Kind": "var",
       "File": "multiple_mains/main2.go",
@@ -74,7 +74,7 @@
         "Kind": "var",
         "PackageImportPath": "github.com/sgtest/go-misc/multiple_mains"
       },
-      "TreePath": "./main2/main/x"
+      "TreePath": "./main2/main/x/1"
     }
   ],
   "Refs": [
@@ -128,7 +128,7 @@
     {
       "DefUnitType": "GoPackage",
       "DefUnit": "github.com/sgtest/go-misc/multiple_mains",
-      "DefPath": "main2.go/main/x",
+      "DefPath": "main2.go/main/x/1",
       "Unit": "github.com/sgtest/go-misc/multiple_mains",
       "File": "multiple_mains/main2.go",
       "Start": 111,
@@ -137,7 +137,7 @@
     {
       "DefUnitType": "GoPackage",
       "DefUnit": "github.com/sgtest/go-misc/multiple_mains",
-      "DefPath": "main2.go/main/x",
+      "DefPath": "main2.go/main/x/1",
       "Unit": "github.com/sgtest/go-misc/multiple_mains",
       "Def": true,
       "File": "multiple_mains/main2.go",


### PR DESCRIPTION
This is to avoid a path collision between an interface method's name and a parameter with the same name of another method of the same interface. Tried long to find some less radical workaround, found none. Proper fix needs major rewrite of this code based on AST traversal. Feeling bad...